### PR TITLE
Section on how to add IAM policy for KMS grants

### DIFF
--- a/doc_source/encryption-at-rest.md
+++ b/doc_source/encryption-at-rest.md
@@ -37,6 +37,28 @@ In order to use the Amazon ES console to create a domain that encrypts data at r
 
 If you want to use a key other than **\(Default\) aws/es**, you must also have permissions to create [grants](http://docs.aws.amazon.com/kms/latest/developerguide/grants.html) for the key\. These permissions typically take the form of a resource\-based policy that you specify when you create the key\. To learn more, see [Using Key Policies in AWS KMS](http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html) in the *AWS Key Management Service Developer Guide*\.
 
+
+## IAM Policy to Create KMS Grants<a name="disabling-ear"></a>
+
+If you want to restrict the user to create KMS grants only for ElasticSearch service, you can restrict it by using an IAM policy like that:
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "kms:CreateGrant",
+      "Resource": "arn:aws:kms:[region]:[accountid]:key/[key_id]",
+      "Condition": {
+        "StringEquals": {
+          "kms:GranteePrincipal": "arn:aws:iam::[elasticsearch_controlplane_account]:user/super"
+        }
+      }
+    }
+  ]
+}
+```
+
 ## Disabling Encryption of Data at Rest<a name="disabling-ear"></a>
 
 After you configure a domain to encrypt data at rest, you can't disable the setting\. Instead, you can take a [manual snapshot](es-managedomains-snapshots.md) of the existing domain, [create another domain](es-createupdatedomains.md#es-createdomains), migrate your data, and delete the old domain\.


### PR DESCRIPTION
I have added a section explaining how to create an IAM policy that only allow Elasticsearch to create grants on the KMS key. Companies that must create rules based on least privilege access will need to create specific policies.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
