### PR TITLE
Python - session_token is required for role based access

### DIFF
--- a/doc_source/es-request-signing.md
+++ b/doc_source/es-request-signing.md
@@ -163,7 +163,7 @@ region = '' # e.g. us-west-1
 
 service = 'es'
 credentials = boto3.Session().get_credentials()
-awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service)
+awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
 
 es = Elasticsearch(
     hosts = [{'host': host, 'port': 443}],


### PR DESCRIPTION
The Python example would not worked from outside AWS (for example, local machines) if the Elasticsearch has role based access and users are assuming a role via their AWS credentials. The token has to be supplied and this PR proposes the correct usage of `requests_aws4auth.AWS4Auth` in such a scenario.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
