### PR TITLE
Fix GET endpoint

### DIFF
--- a/doc_source/fgac.md
+++ b/doc_source/fgac.md
@@ -643,7 +643,7 @@ Permissions vary based on the actions each service performs\. An AWS IoT rule or
 
 ## REST API Differences<a name="fgac-rest-api"></a>
 
-The fine\-grained access control REST API differs slightly depending on your Elasticsearch version\. Prior to making a `PUT` request, make a `GET` request to verify the expected request body\. For example, a `GET` request to `_opendistro/_security/api/users` returns all users, which you can then modify and use to make valid `PUT` requests\.
+The fine\-grained access control REST API differs slightly depending on your Elasticsearch version\. Prior to making a `PUT` request, make a `GET` request to verify the expected request body\. For example, a `GET` request to `_opendistro/_security/api/user/` returns all users, which you can then modify and use to make valid `PUT` requests\.
 
 On Elasticsearch 6\.*x*, requests to create users look like this:
 


### PR DESCRIPTION
Tested on ESearch 7.1 BUILD R20200302.

The original call:
_opendistro/_security/api/users

Returns:
{
  "error": "no handler found for uri [/_opendistro/_security/api/users/?pretty] and method [GET]"
}

This:
GET _opendistro/_security/api/user/

Returns the list of users.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
