### PR TITLE
Fix CLI policy statement

### DIFF
--- a/doc_source/es-createupdatedomains.md
+++ b/doc_source/es-createupdatedomains.md
@@ -521,7 +521,7 @@ aws logs describe-log-groups --log-group-name my-log-group
 Now you can give Amazon ES permissions to write to the log group\. You must provide the log group's ARN near the end of the command:
 
 ```
-aws logs put-resource-policy --policy-name my-policy --policy-document '{ "Version": "2012-10-17", "Statement": [{ "Sid": "", "Effect": "Allow", "Principal": { "Service": "es.amazonaws.com"}, "Action":[ "logs:PutLogEvents"," logs:PutLogEventsBatch","logs:CreateLogStream"],"Resource": "cw_log_group_arn"}]}'
+aws logs put-resource-policy --policy-name my-policy --policy-document '{ "Version": "2012-10-17", "Statement": [{ "Sid": "", "Effect": "Allow", "Principal": { "Service": "es.amazonaws.com"}, "Action":[ "logs:PutLogEvents","logs:PutLogEventsBatch","logs:CreateLogStream"],"Resource": "cw_log_group_arn"}]}'
 ```
 
 **Important**  


### PR DESCRIPTION
*Description of changes:*

Removed a typo (an unwanted space) in the policy statement of the CLI command example given. 

With the typo, the policy is created successfully, but does not grant sufficient permission to the ElasticSearch service role. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
