### PR TITLE
Change the snapshot's name - change the "second" to "minute"

### DIFF
--- a/doc_source/curator.md
+++ b/doc_source/curator.md
@@ -103,7 +103,7 @@ awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, servi
 
 now = datetime.now()
 # Clunky, but this approach keeps colons out of the URL.
-date_string = '-'.join((str(now.year), str(now.month), str(now.day), str(now.hour), str(now.second)))
+date_string = '-'.join((str(now.year), str(now.month), str(now.day), str(now.hour), str(now.minute)))
 
 snapshot_name = 'my-snapshot-prefix-' + date_string
 repository_name = 'my-repo'


### PR DESCRIPTION
Since we are saving the time of the snapshots' creation, its good idea to use minute instead of second in the snapshot's name

*Issue #, if available:*
Using the seconds parameter as part of the snapshot's name can cause issues it the same name might exists already, if we are running it in the same second but in a different minute.

*Description of changes:*
Changed the usage of "now.second" to "now.minute" to improve the stability of the script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
