### PR TITLE
Fix Snapshot name is not updated + use minute instead of seconds

### DIFF
--- a/doc_source/curator.md
+++ b/doc_source/curator.md
@@ -101,15 +101,16 @@ service = 'es'
 credentials = boto3.Session().get_credentials()
 awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
 
-now = datetime.now()
-# Clunky, but this approach keeps colons out of the URL.
-date_string = '-'.join((str(now.year), str(now.month), str(now.day), str(now.hour), str(now.second)))
-
-snapshot_name = 'my-snapshot-prefix-' + date_string
 repository_name = 'my-repo'
 
 # Lambda execution starts here.
 def lambda_handler(event, context):
+
+    now = datetime.now()
+    
+    # Clunky, but this approach keeps colons out of the URL.
+    date_string = '-'.join((str(now.year), str(now.month), str(now.day), str(now.hour), str(now.minute)))
+    snapshot_name = 'my-snapshot-prefix-' + date_string
 
     # Build the Elasticsearch client.
     es = Elasticsearch(


### PR DESCRIPTION
The snapshot's name should be initiated in the lambda method, otherwise, the time used will be a constant and won't get updated on each invocation.
Also, since we are saving the time of the snapshots' creation, its good idea to use minute instead of second in the snapshot's name

*Issue #, if available:*
The lambda method is trying to use the same snapshot name cross invocations + is using the "now.second" instead of "now.minute" (can result false positive of "snapshot already exists" in case we are it in the same second but different minute in the same hour of the day).

*Description of changes:*
Move the snapshot's name initiation in the lambda handler and changed the usage of "now.second" to "now.minute" to improve the stability of the script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
