### PR TITLE
Fixing example python code for ES snapshot management

### DIFF
--- a/doc_source/es-managedomains-snapshots.md
+++ b/doc_source/es-managedomains-snapshots.md
@@ -89,7 +89,7 @@ payload = {
   "type": "s3",
   "settings": {
     "bucket": "s3-bucket-name",
-    # "endpoint": "us-east-1", # for us-east-1
+    # "endpoint": "s3.amazonaws.com", # for us-east-1
     "region": "us-west-1", # for all other regions
     "role_arn": "arn:aws:iam::123456789012:role/TheSnapshotRole"
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Although the guide says to use the s3.amazonaws.com endpoint for buckets in us-east-1, the example code uses the region name instead. This doesn't work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
