### PR TITLE
Update es-service-software.md

### DIFF
--- a/doc_source/es-service-software.md
+++ b/doc_source/es-service-software.md
@@ -9,7 +9,7 @@ Each notification includes details about the service software update\. The notif
 + If you take no action on required updates, Amazon ES still updates your domain service software automatically after a certain timeframe \(typically two weeks\)\. In this situation, Amazon ES sends notifications when it starts the update and when the update is complete\.
 + If you start an update manually, Amazon ES doesn't send a notification when it starts the update, only when the update is complete\.
 
-Manually updating your domain lets you take advantage of new features more quickly\. Consider starting the update at a low traffic time\. Your domain is ineligible for a service software update if it's in any of the following states:
+Manually updating your domain lets you take advantage of new features more quickly\. Your domain is ineligible for a service software update if it's in any of the following states:
 
 
 | State | Description | 


### PR DESCRIPTION
In my testing pressing the button to upgrade the AWS ES software seems to get you in a queue but doesn't control _when_ the install happens. So, just because I click the button to install after-hours doesn't mean the install will follow in that time frame. In short, the install time _cannot_ be controlled. So, removing this comment.