### PR TITLE
converted binary to string

### DIFF
--- a/doc_source/es-aws-integrations.md
+++ b/doc_source/es-aws-integrations.md
@@ -82,6 +82,7 @@ Deployment packages are ZIP or JAR files that contain your code and its dependen
            
            # Match the regular expressions to each line and index the JSON
            for line in lines:
+               line = line.decode("utf-8")
                ip = ip_pattern.search(line).group(1)
                timestamp = time_pattern.search(line).group(1)
                message = message_pattern.search(line).group(1)


### PR DESCRIPTION
*Issue #, if available:* On using the complete code, the following error occurs in the Lambda function. 

```
{
  "errorMessage": "cannot use a string pattern on a bytes-like object",
  "errorType": "TypeError",
  "stackTrace": [
    "  File \"/var/task/sample.py\", line 40, in handler\n    ip = ip_pattern.search(line).group(1)\n"
  ]
}
```

*Description of changes:*

I am converting "line" which is a byte object to "string" inside inner most for loop using the below statement.

```
line = line.decode("utf-8")
```

After converting to String, the code worked successfully. 

Please let me know if any more information is required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
