### PR TITLE
Add a note for existing clusters

### DIFF
--- a/doc_source/saml.md
+++ b/doc_source/saml.md
@@ -2,8 +2,8 @@
 
 SAML authentication for Kibana lets you use your existing identity provider to offer single sign\-on \(SSO\) for Kibana on Amazon Elasticsearch Service \(Amazon ES\) domains running Elasticsearch 6\.7 or later\. To use SAML authentication, you must enable [fine\-grained access control](fgac.md)\.
 
-**Important**  
-You can't enable fine-grained access control on existing domains, only new ones. After you enable fine-grained access control, you can't disable it. 
+**Note**  
+You can't enable fine-grained access control on existing domains, only new ones. By extension, this means you can only enable SAML authentication on new domains or existing ones that have fine-grained access control already enabled\.
 
 Rather than authenticating through [Amazon Cognito](es-cognito-auth.md) or the [internal user database](fgac.md#fgac-kibana), SAML authentication for Kibana lets you use third\-party identity providers to log in to Kibana, manage fine\-grained access control, search your data, and build visualizations\. Amazon ES supports providers that use the SAML 2\.0 standard, such as Okta, Keycloak, Active Directory Federation Services \(ADFS\), and Auth0\. Requests from Amazon ES to third\-party providers aren't explicitly encrypted with a service provider certificate\.
 

--- a/doc_source/saml.md
+++ b/doc_source/saml.md
@@ -2,6 +2,9 @@
 
 SAML authentication for Kibana lets you use your existing identity provider to offer single sign\-on \(SSO\) for Kibana on Amazon Elasticsearch Service \(Amazon ES\) domains running Elasticsearch 6\.7 or later\. To use SAML authentication, you must enable [fine\-grained access control](fgac.md)\.
 
+**Important**  
+You can't enable fine-grained access control on existing domains, only new ones. After you enable fine-grained access control, you can't disable it. 
+
 Rather than authenticating through [Amazon Cognito](es-cognito-auth.md) or the [internal user database](fgac.md#fgac-kibana), SAML authentication for Kibana lets you use third\-party identity providers to log in to Kibana, manage fine\-grained access control, search your data, and build visualizations\. Amazon ES supports providers that use the SAML 2\.0 standard, such as Okta, Keycloak, Active Directory Federation Services \(ADFS\), and Auth0\. Requests from Amazon ES to third\-party providers aren't explicitly encrypted with a service provider certificate\.
 
 SAML authentication for Kibana is only for accessing Kibana through a web browser\. Your SAML credentials do *not* let you make direct HTTP requests to the Elasticsearch or Kibana APIs\. 


### PR DESCRIPTION
Existing cluster where fine-grain access control is not enable, cannot use SAML even running on the latest version. I suggest to put some clarifications of this in the SAML documentation for customer with existing cluster that are interested in this feature as fine-grained security is disabled by default.

*Issue #, if available:*

*Description of changes:*
Added a note to the page related to existing clusters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
